### PR TITLE
Added Comments Color Scheme Options to Facebook Comments

### DIFF
--- a/administrator/com_myapi/extensions/plg_myapicomment/myApiComment.php
+++ b/administrator/com_myapi/extensions/plg_myapicomment/myApiComment.php
@@ -66,6 +66,7 @@ class plgContentmyApiComment extends JPlugin
 			$comments_width = $myapiparama->get('comments_width');
 			$comments_numposts = $myapiparama->get('comments_numposts');
 			$comments_publish_feed = $myapiparama->get('comments_publish_feed');
+			$comments_color_scheme = $myapiparama->get('comments_color_scheme');
 			
 			$comments_view_article = $myapiparama->get('comments_view_article');
 			$comments_view_list = $myapiparama->get('comments_view_list');
@@ -122,11 +123,11 @@ class plgContentmyApiComment extends JPlugin
 			if($comment_show && $hasAccess )
 			{
 				
-				$comment_box = '<fb:comments app_id="'.$facebook->getAppId().'" migrated="1" xid="'.$xid.'" url="'.$commentURL.'" numposts="'.$comments_numposts.'" width="'.$comments_width.'" publish_feed="'.$comments_publish_feed.'"></fb:comments>';
+				$comment_box = '<fb:comments app_id="'.$facebook->getAppId().'" migrated="1" xid="'.$xid.'" url="'.$commentURL.'" numposts="'.$comments_numposts.'" width="'.$comments_width.'" publish_feed="'.$comments_publish_feed.'" colorscheme="'.$comments_color_scheme.'"></fb:comments>';
 				
 				$comment_link = "<br /><a id='".$xid."commentLink' class='' href='#'>Add a comment</a><br />";
 				
-				$js = "window.addEvent('domready',function(){ $('".$xid."commentLink').addEvent('click',function(){ myApiModal.open(\"Leave a comment.\",null,\"<fb:comments app_id=\'".$facebook->getAppId()."\' migrated=\'1\' xid=\'".$xid."\' url=\'".$commentURL."\' numposts=\'5\' width=\'700\' publish_feed=\'".$comments_publish_feed."\'></fb:comments>\"); }); });";
+				$js = "window.addEvent('domready',function(){ $('".$xid."commentLink').addEvent('click',function(){ myApiModal.open(\"Leave a comment.\",null,\"<fb:comments app_id=\'".$facebook->getAppId()."\' migrated=\'1\' xid=\'".$xid."\' url=\'".$commentURL."\' numposts=\'5\' width=\'700\' publish_feed=\'".$comments_publish_feed."\' colorscheme=\'".$comments_color_scheme."\'></fb:comments>\"); }); });";
 				
 				if(JRequest::getVar('view','','get') == 'article'){
 					//article	

--- a/administrator/com_myapi/extensions/plg_myapicomment/myApiComment.php
+++ b/administrator/com_myapi/extensions/plg_myapicomment/myApiComment.php
@@ -123,11 +123,11 @@ class plgContentmyApiComment extends JPlugin
 			if($comment_show && $hasAccess )
 			{
 				
-				$comment_box = '<fb:comments app_id="'.$facebook->getAppId().'" migrated="1" xid="'.$xid.'" url="'.$commentURL.'" numposts="'.$comments_numposts.'" width="'.$comments_width.'" publish_feed="'.$comments_publish_feed.'" colorscheme="'.$comments_color_scheme.'"></fb:comments>';
+				$comment_box = '<fb:comments app_id="'.$facebook->getAppId().'" migrated="1" xid="'.$xid.'" href="'.$commentURL.'" numposts="'.$comments_numposts.'" width="'.$comments_width.'" publish_feed="'.$comments_publish_feed.'" colorscheme="'.$comments_color_scheme.'"></fb:comments>';
 				
 				$comment_link = "<br /><a id='".$xid."commentLink' class='' href='#'>Add a comment</a><br />";
 				
-				$js = "window.addEvent('domready',function(){ $('".$xid."commentLink').addEvent('click',function(){ myApiModal.open(\"Leave a comment.\",null,\"<fb:comments app_id=\'".$facebook->getAppId()."\' migrated=\'1\' xid=\'".$xid."\' url=\'".$commentURL."\' numposts=\'5\' width=\'700\' publish_feed=\'".$comments_publish_feed."\' colorscheme=\'".$comments_color_scheme."\'></fb:comments>\"); }); });";
+				$js = "window.addEvent('domready',function(){ $('".$xid."commentLink').addEvent('click',function(){ myApiModal.open(\"Leave a comment.\",null,\"<fb:comments app_id=\'".$facebook->getAppId()."\' migrated=\'1\' xid=\'".$xid."\' href=\'".$commentURL."\' numposts=\'5\' width=\'700\' publish_feed=\'".$comments_publish_feed."\' colorscheme=\'".$comments_color_scheme."\'></fb:comments>\"); }); });";
 				
 				if(JRequest::getVar('view','','get') == 'article'){
 					//article	

--- a/administrator/com_myapi/extensions/plg_myapicomment/myApiComment.xml
+++ b/administrator/com_myapi/extensions/plg_myapicomment/myApiComment.xml
@@ -38,9 +38,9 @@
 		  	<option value="1">Yes</option>
 		</param>
 
-		<param name="comments_color_scheme" type="radio" default="0" label="Choose a Light or Dark Color Scheme" description="This lets you choose a Light or Dark color scheme for Facebook comments. Default is the Light Theme.">
-			<option value="0">Light</option>
-		  	<option value="1">Dark</option>
+		<param name="comments_color_scheme" type="list" default="light" label="Choose a Light or Dark Color Scheme" description="This lets you choose a Light or Dark color scheme for Facebook comments. Default is the Light Theme.">
+			<option value="light">Light</option>
+		  	<option value="dark">Dark</option>
 		</param>
 		
 		<param name="comments_show_on" type="radio" default="all" label="Select an option" description="">

--- a/administrator/com_myapi/extensions/plg_myapicomment/myApiComment.xml
+++ b/administrator/com_myapi/extensions/plg_myapicomment/myApiComment.xml
@@ -37,6 +37,11 @@
 			<option value="0">No</option>
 		  	<option value="1">Yes</option>
 		</param>
+
+		<param name="comments_color_scheme" type="radio" default="0" label="Choose a Light or Dark Color Scheme" description="This lets you choose a Light or Dark color scheme for Facebook comments. Default is the Light Theme.">
+			<option value="0">Light</option>
+		  	<option value="1">Dark</option>
+		</param>
 		
 		<param name="comments_show_on" type="radio" default="all" label="Select an option" description="">
 			<option value="all">Show on all articles &lt;br/&gt;</option>


### PR DESCRIPTION
Hey Thomas, I updated the FB:Comments code so it can use the new dark color scheme. I QA'd the comments on my test site and everything came up fine.  Please check / QA the code before committing it to the main branch. 

Important Note: If I was viewing the comments and was logged in as the Facebook admin, only the Light color scheme would appear.  If I was logged out of Facebook or wasn't the admin for that site, the Dark color scheme appeared. I assume this is a Facebook bug, but I've haven't searched around enough to see if it's been submitted to them. 

Color scheme info here: http://developers.facebook.com/blog/post/490
