### PR TITLE
Update myApiComment.php

### DIFF
--- a/administrator/com_myapi/extensions/plg_myapicomment/myApiComment.php
+++ b/administrator/com_myapi/extensions/plg_myapicomment/myApiComment.php
@@ -66,7 +66,7 @@ class plgContentmyApiComment extends JPlugin
 	function getComments($xid){
 		$params  =   array(
 		 'method'    => 'fql.query',
-		 'query'     => "SELECT username,fromid,text,time FROM comment WHERE xid='".$xid."';"
+		 'query'     => "SELECT username,fromid,text,time FROM comment WHERE id='".$xid."';"
 		);
 		$facebook = plgSystemmyApiConnect::getFacebook();
 		$fqlResult   =   $facebook->api($params);


### PR DESCRIPTION
Facebook changed the documentation. causing the query:
"SELECT username,fromid,text,time FROM comment WHERE xid='".$xid."';" to fail with this error: 
Your statement is not indexable. The WHERE clause must contain an indexable column. 
Such columns are marked with \* in the tables linked from http://developers.facebook.com/docs/reference/fql 

The FB new reference show that you should use id and not xid:
https://developers.facebook.com/docs/reference/fql/comment

it is planned change that was being rolled out in FB roadmap:
https://developers.facebook.com/roadmap/
"Removing 'xid', 'reply_xid', 'username' and 'comments' from 'comment' FQL table
We are removing the fields on the FQL 'comment' table that were used exclusively for legacy Comments Plugins -- 'xid', 'reply_xid', 'username' and 'comments'. We now treat comments the same across plugins and within Facebook. Please query for comment replies left on the plugin the same way as you would for other comments."
